### PR TITLE
Markdown

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,7 @@ from telebot.util import smart_split
 from telegramify_markdown import markdownify
 
 from ai import translate
-from config import MAX_MESSAGE_LENGHT, bot
+from config import MAX_MESSAGE_LENGTH, bot
 from database import auth, register_user
 
 
@@ -39,7 +39,7 @@ def handle_text(message):
     try:
         translation = translate(message.text.strip())
         translation = markdownify(translation)
-        if len(translation) > MAX_MESSAGE_LENGHT:
+        if len(translation) > MAX_MESSAGE_LENGTH:
             chunks = smart_split(translation, 4096)
             for text in chunks:
                 bot.reply_to(

--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,5 @@
-from markdown import markdown
-from sulguk import transform_html
 from telebot.util import smart_split
+from telegramify_markdown import markdownify
 
 from ai import translate
 from config import MAX_MESSAGE_LENGHT, bot
@@ -39,14 +38,17 @@ def handle_text(message):
 
     try:
         translation = translate(message.text.strip())
-        translation = markdown(translation)
-        translation = transform_html(translation)
-        if len(translation.text) > MAX_MESSAGE_LENGHT:
-            chunks = smart_split(translation.text, 4096)
+        translation = markdownify(translation)
+        if len(translation) > MAX_MESSAGE_LENGHT:
+            chunks = smart_split(translation, 4096)
             for text in chunks:
-                bot.reply_to(message, text)
+                bot.reply_to(
+                    message,
+                    text,
+                    parse_mode="MarkdownV2",
+                )
         else:
-            bot.reply_to(message, translation.text, entities=translation.entities)
+            bot.reply_to(message, translation, parse_mode="MarkdownV2")
     except Exception as e:
         bot.reply_to(message, f"Unexpected: {e}")
 

--- a/bot.py
+++ b/bot.py
@@ -3,7 +3,7 @@ from sulguk import transform_html
 from telebot.util import smart_split
 
 from ai import translate
-from config import bot
+from config import MAX_MESSAGE_LENGHT, bot
 from database import auth, register_user
 
 
@@ -41,7 +41,7 @@ def handle_text(message):
         translation = translate(message.text.strip())
         translation = markdown(translation)
         translation = transform_html(translation)
-        if len(translation.text) > 4096:
+        if len(translation.text) > MAX_MESSAGE_LENGHT:
             chunks = smart_split(translation.text, 4096)
             for text in chunks:
                 bot.reply_to(message, text)

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ if os.getenv("ENV") != "PROD":
     load_dotenv()
 
 TG_API_TOKEN = os.environ["TG_API_TOKEN"]
-bot = TeleBot(token=TG_API_TOKEN, parse_mode="HTML", disable_web_page_preview=True)
+bot = TeleBot(token=TG_API_TOKEN, disable_web_page_preview=True)
 
 
 GEMINI_API_KEY = os.environ["GEMINI_API_KEY"]

--- a/config.py
+++ b/config.py
@@ -26,7 +26,7 @@ gemini_flash_model = genai.GenerativeModel(
 )
 
 
-MAX_MESSAGE_LENGHT = 4096
+MAX_MESSAGE_LENGTH = 4096
 
 
 TARGET_LANGUAGE = os.getenv("TARGET_LANGUAGE")

--- a/config.py
+++ b/config.py
@@ -26,6 +26,9 @@ gemini_flash_model = genai.GenerativeModel(
 )
 
 
+MAX_MESSAGE_LENGHT = 4096
+
+
 TARGET_LANGUAGE = os.getenv("TARGET_LANGUAGE")
 
 

--- a/database.py
+++ b/database.py
@@ -41,5 +41,4 @@ def register_user(
             approved=approved,
         )
         return True
-    else:
-        return False  # already registered user
+    return False  # already registered user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,67 @@
+[tool.pylint]
+disable = ["C0114", "C0116", "W0718"]
+
+[tool.ruff]
+exclude = ["temp"]
+line-length = 88
+indent-width = 4
+target-version = "py312"
+
+[tool.ruff.lint]
+select = [
+  "E",    # pycodestyle
+  "F",    # Pyflakes
+  "B",    # flake8-bugbear
+  "I",    # isort
+  "W",    # pycodestyle
+  "SIM",  # flake8-simplify
+  "UP",   # pyupgrade
+  "LOG",  # flake8-logging
+  "G",    # flake8-logging-format
+  "PT",   # flake8-pytest-style
+  "S",    # flake8-bandit
+  "DTZ",  # flake8-datetimez
+  "Q",    # flake8-quotes
+  "RET",  # flake8-return
+  "TID",  # flake8-tidy-imports
+  "PTH",  # flake8-use-pathlib
+  "PERF", # Perflint
+  "FURB", # refurb
+  "RUF",  # Ruff-specific rules
+  "C90",  # mccabe
+  "N",    # pep8-naming
+  "A",    # flake8-builtins
+  "COM",  # flake8-commas
+  "CPY",  # flake8-copyright
+  "C4",   # flake8-comprehensions
+  "ICN",  # flake8-import-conventions
+  "T20",  # flake8-print
+  "RSE",  # flake8-raise
+  "TCH",  # flake8-type-checking
+  "ARG",  # flake8-unused-arguments
+  "FIX",  # flake8-fixme
+  "ERA",  # eradicate
+  "PL",   # Pylint
+  "FLY",  # flynt
+]
+ignore = []
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ pyTelegramBotAPI==4.23.0
 google-generativeai==0.8.3
 pony==0.7.19
 psycopg2-binary==2.9.9
-Markdown==3.7
-sulguk==0.8.0
+telegramify_markdown==0.1.13


### PR DESCRIPTION
## Summary by Sourcery

Refactor the bot's message handling to use 'markdownify' for translations and ensure messages are sent with 'MarkdownV2' parse mode. Simplify the 'register_user' function logic and introduce a constant for maximum message length.

Enhancements:
- Refactor the translation handling to use 'markdownify' instead of 'markdown' and 'transform_html'.
- Simplify the return logic in 'register_user' function by removing unnecessary else statement.