### PR TITLE
chore(workflow): update branches-ignore to only exclude 'main' branch…

### DIFF
--- a/.github/workflows/opencommit.yml
+++ b/.github/workflows/opencommit.yml
@@ -2,7 +2,7 @@ name: "OpenCommit Action"
 
 on:
   push:
-    branches-ignore: [main master dev development release]
+    branches-ignore: [main]
 
 jobs:
   opencommit:
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: di-sukharev/opencommit@github-action-v1.0.4
+      - uses: di-sukharev/opencommit@4e25f1460af4747fba99415afec991f3dfe8444f # github-action-v1.0.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
… for push events

chore(workflow): update opencommit action version to a specific commit for stability and consistency

## Summary by Sourcery

Update the GitHub Actions workflow to refine branch exclusion and ensure stability by pinning the opencommit action to a specific commit.

CI:
- Update the branches-ignore configuration in the workflow to only exclude the 'main' branch for push events.
- Pin the opencommit action version to a specific commit hash for stability and consistency.